### PR TITLE
add HealthCheck

### DIFF
--- a/Poliedro.Report.Api/Poliedro.Report.Api.csproj
+++ b/Poliedro.Report.Api/Poliedro.Report.Api.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.MySql" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="MediatR" Version="12.5.0" />

--- a/Poliedro.Report.Api/Program.cs
+++ b/Poliedro.Report.Api/Program.cs
@@ -3,6 +3,9 @@ using Poliedro.Billing.Api.Common.Configurations;
 using Poliedro.Report.Application;
 using Poliedro.Report.Application.Ports.Redis;
 using Poliedro.Report.Infraestructure.Persistence.Mysql;
+using HealthChecks.UI.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 
 var builder = WebApplication.CreateBuilder(args);
 var config = builder.Configuration;
@@ -15,6 +18,12 @@ builder.Services
     .AddWebApi()
     .AddApplication()
     .AddPersistence(builder.Configuration);
+var connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? builder.Configuration["ConnectionStrings:MysqlConnection"];
+
+builder.Services.AddHealthChecks()
+    .AddMySql(connectionString, name: "sql", tags: ["ready"])
+    .AddRedis(builder.Configuration["Redis:ConnectionString"], name: "redis", tags: ["ready"]);
+    
 builder.Services.Configure<RedisConfig>(builder.Configuration.GetSection("Redis"));
 builder.Services.AddControllers(options =>
 {
@@ -37,6 +46,10 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
+app.MapHealthChecks("/health", new HealthCheckOptions()
+{
+    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+});
 app.UseCors("PoliedroReport");
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
## Summary by Sourcery

Add HealthCheck endpoint to report readiness of application dependencies

New Features:
- Register health checks for MySQL and Redis using configuration and environment variables
- Expose a `/health` endpoint with UIResponseWriter for health status responses