### PR TITLE
Refactor /move redist to handle

### DIFF
--- a/Poliedro.Report.Api/Program.cs
+++ b/Poliedro.Report.Api/Program.cs
@@ -5,6 +5,7 @@ using Poliedro.Report.Api;
 using Poliedro.Report.Application;
 using Poliedro.Report.Application.Ports.Redis;
 using Poliedro.Report.Infraestructure.Persistence.Mysql;
+using Poliedro.Report.Infraestructure.Persistence.Mysql.Redis; // ¡Nuevo using!
 
 var builder = WebApplication.CreateBuilder(args);
 var config = builder.Configuration;
@@ -17,12 +18,17 @@ builder.Services
     .AddWebApi()
     .AddApplication()
     .AddPersistence(builder.Configuration);
+
+// ¡Añade esta línea para registrar RedisCacheService como la implementación de IRedisService!
+// Usamos AddSingleton porque ConnectionMultiplexer está diseñado para ser una instancia única y compartida.
+builder.Services.AddSingleton<IRedisService, RedisCacheService>();
+
 var connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? builder.Configuration["ConnectionStrings:MysqlConnection"];
 
 builder.Services.AddHealthChecks()
     .AddMySql(connectionString, name: "sql", tags: ["ready"])
     .AddRedis(builder.Configuration["Redis:ConnectionString"], name: "redis", tags: ["ready"]);
-    
+
 builder.Services.Configure<RedisConfig>(builder.Configuration.GetSection("Redis"));
 builder.Services.AddControllers(options =>
 {

--- a/Poliedro.Report.Api/Program.cs
+++ b/Poliedro.Report.Api/Program.cs
@@ -5,7 +5,8 @@ using Poliedro.Report.Api;
 using Poliedro.Report.Application;
 using Poliedro.Report.Application.Ports.Redis;
 using Poliedro.Report.Infraestructure.Persistence.Mysql;
-using Poliedro.Report.Infraestructure.Persistence.Mysql.Redis; 
+using Poliedro.Report.Infraestructure.Persistence.Mysql.Redis;
+using StackExchange.Redis; 
 
 var builder = WebApplication.CreateBuilder(args);
 var config = builder.Configuration;
@@ -13,6 +14,7 @@ var config = builder.Configuration;
 // Configura el logging
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
+
 
 builder.Services
     .AddWebApi()
@@ -22,13 +24,25 @@ builder.Services
 
 builder.Services.AddSingleton<IRedisService, RedisCacheService>();
 
-var connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? builder.Configuration["ConnectionStrings:MysqlConnection"];
+
+builder.Services.AddSingleton<IConnectionMultiplexer>(sp =>
+{
+    var configuration = builder.Configuration.GetSection("Redis")["ConnectionString"];
+    return ConnectionMultiplexer.Connect(configuration);
+});
+
+
+var connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION")
+                       ?? builder.Configuration["ConnectionStrings:MysqlConnection"];
 
 builder.Services.AddHealthChecks()
     .AddMySql(connectionString, name: "sql", tags: ["ready"])
     .AddRedis(builder.Configuration["Redis:ConnectionString"], name: "redis", tags: ["ready"]);
 
+
 builder.Services.Configure<RedisConfig>(builder.Configuration.GetSection("Redis"));
+
+
 builder.Services.AddControllers(options =>
 {
     options.Filters.Add<GlobalExceptionConfiguration>();
@@ -37,6 +51,8 @@ builder.Services.AddControllers(options =>
 builder.Services.AddRouting(routing => routing.LowercaseUrls = true);
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("PoliedroReport", policy =>
@@ -50,11 +66,17 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
+
+
 app.MapHealthChecks("/health", new HealthCheckOptions()
 {
     ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
 });
+
+
 app.UseCors("PoliedroReport");
+
+
 if (app.Environment.IsDevelopment())
 {
     app.UseDeveloperExceptionPage();

--- a/Poliedro.Report.Api/Program.cs
+++ b/Poliedro.Report.Api/Program.cs
@@ -5,7 +5,7 @@ using Poliedro.Report.Api;
 using Poliedro.Report.Application;
 using Poliedro.Report.Application.Ports.Redis;
 using Poliedro.Report.Infraestructure.Persistence.Mysql;
-using Poliedro.Report.Infraestructure.Persistence.Mysql.Redis; // ¡Nuevo using!
+using Poliedro.Report.Infraestructure.Persistence.Mysql.Redis; 
 
 var builder = WebApplication.CreateBuilder(args);
 var config = builder.Configuration;
@@ -19,8 +19,7 @@ builder.Services
     .AddApplication()
     .AddPersistence(builder.Configuration);
 
-// ¡Añade esta línea para registrar RedisCacheService como la implementación de IRedisService!
-// Usamos AddSingleton porque ConnectionMultiplexer está diseñado para ser una instancia única y compartida.
+
 builder.Services.AddSingleton<IRedisService, RedisCacheService>();
 
 var connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? builder.Configuration["ConnectionStrings:MysqlConnection"];

--- a/Poliedro.Report.Api/appsettings.json
+++ b/Poliedro.Report.Api/appsettings.json
@@ -17,6 +17,7 @@
     "https://poliedro.cloud"
   ],
   "Redis": {
-    "ConnectionString": "18.117.10.34:6379"
+    "ConnectionString": "18.117.10.34:6379",
+    "ExpirationInMinutes": 1440
   }
 }

--- a/Poliedro.Report.Api/appsettings.json
+++ b/Poliedro.Report.Api/appsettings.json
@@ -17,7 +17,7 @@
     "https://poliedro.cloud"
   ],
   "Redis": {
-    "ConnectionString": "18.117.10.34:6379",
+    "ConnectionString": "3.16.55.93:6379",
     "ExpirationInMinutes": 1440
   }
 }

--- a/Poliedro.Report.Application/DraftReport2/Queries/GetAllDraftReport/GetAllDraftReportQueryHandler.cs
+++ b/Poliedro.Report.Application/DraftReport2/Queries/GetAllDraftReport/GetAllDraftReportQueryHandler.cs
@@ -1,25 +1,37 @@
-﻿
-using AutoMapper;
+﻿using AutoMapper;
 using MediatR;
+using Microsoft.Extensions.Configuration;
 using Poliedro.Billing.Application.DraftReport.Dtos;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
 using Poliedro.Billing.Domain.DraftReport.DomainDraftReport;
+using Poliedro.Billing.Domain.DraftReport.Entities;
+using Poliedro.Report.Application.Ports.Redis;
 
 namespace Poliedro.Billing.Application.DraftReport.Queries.GetAllDraftReport;
 
 public class GetAllDraftReportQueryHandler
 (
     IDraftReportDomainDraftReport DraftReportDomainDraftReport,
-    IMapper mapper
+    IMapper mapper,
+    IRedisService redisService,
+    IConfiguration config
 ) : IRequestHandler<GetAllDraftReportQuery, Result<IEnumerable<DraftReportDto>, Error>>
 {
 
     public async Task<Result<IEnumerable<DraftReportDto>, Error>>
         Handle(GetAllDraftReportQuery request, CancellationToken cancellationToken)
     {
+        string cacheKey = $"draftReport_{request.paginationParams.PageNumber}_{request.paginationParams.PageSize}";
+        var cachedData = await redisService.GetCacheAsync<IEnumerable<DraftReportEntity>>(cacheKey);
+        if (cachedData is not null && cachedData.Any())
+        {
+            var mappedData = mapper.Map<List<DraftReportDto>>(cachedData);
+            return Result<IEnumerable<DraftReportDto>, Error>.Success(mappedData);
+        }
+       
         var result = await DraftReportDomainDraftReport.GetAllAsync(cancellationToken, request.paginationParams);
-
+        await redisService.SetCacheAsync(cacheKey, result.Value, TimeSpan.FromMinutes(double.Parse(config["Redis:ExpirationInMinutes"]!)));
         if (!result.IsSuccess && result.Value != null)
             return result.Error!;
 

--- a/Poliedro.Report.Application/InventoryReport/Queries/GetAllInventoryReport/GetAllInventoryReportQueryHandler.cs
+++ b/Poliedro.Report.Application/InventoryReport/Queries/GetAllInventoryReport/GetAllInventoryReportQueryHandler.cs
@@ -1,28 +1,41 @@
-﻿
-using AutoMapper;
+﻿using AutoMapper;
 using MediatR;
 using Poliedro.Billing.Application.InventoryReport.Dtos;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
 using Poliedro.Billing.Domain.InventoryReport.DomainInventoryReport;
+using Poliedro.Report.Application.Ports.Redis;
 
 namespace Poliedro.Billing.Application.InventoryReport.Queries.GetAllInventoryReport;
 
 public class GetAllInventoryReportQueryHandler
 (
-    IInventoryReportDomainInventoryReport InventoryReportDomainInventoryReport,
-    IMapper mapper
+    IInventoryReportDomainInventoryReport inventoryReportDomain,
+    IMapper mapper,
+    IRedisService redisService
 ) : IRequestHandler<GetAllInventoryReportQuery, Result<IEnumerable<InventoryReportDto>, Error>>
 {
 
-    public async Task<Result<IEnumerable<InventoryReportDto>, Error>> 
+    public async Task<Result<IEnumerable<InventoryReportDto>, Error>>
         Handle(GetAllInventoryReportQuery request, CancellationToken cancellationToken)
     {
-        var result = await InventoryReportDomainInventoryReport.GetAllAsync(cancellationToken, request.paginationParams);
+        string cacheKey = $"inventoryReport_{request.paginationParams.PageNumber}_{request.paginationParams.PageSize}";
+
+        var cachedData = await redisService.GetCacheAsync<IEnumerable<InventoryReportDto>>(cacheKey);
+        if (cachedData is not null)
+        {
+            return Result<IEnumerable<InventoryReportDto>, Error>.Success(cachedData);
+        }
+
+        var result = await inventoryReportDomain.GetAllAsync(cancellationToken, request.paginationParams);
 
         if (!result.IsSuccess && result.Value != null)
             return result.Error!;
 
-        return mapper.Map<List<InventoryReportDto>>(result.Value);
+        var dtoList = mapper.Map<List<InventoryReportDto>>(result.Value);
+
+        await redisService.SetCacheAsync(cacheKey, dtoList, TimeSpan.FromMinutes(1440));
+
+        return dtoList;
     }
 }

--- a/Poliedro.Report.Application/InvoiceReport/Queries/GetAllInvoiceReport/GetAllInvoiceReportQueryHandler.cs
+++ b/Poliedro.Report.Application/InvoiceReport/Queries/GetAllInvoiceReport/GetAllInvoiceReportQueryHandler.cs
@@ -3,21 +3,31 @@ using MediatR;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
 using Poliedro.Report.Application.InvoiceReport.Dtos;
+using Poliedro.Report.Application.Ports.Redis;
 using Poliedro.Report.Domain.InvoiceReport.Ports;
 
 namespace Poliedro.Report.Application.InvoiceReport.Queries.GetAllInvoiceReport
 {
     public class GetAllInvoiceReportQueryHandler
-        (
-            IInvoiceReportDomainService InvoiceReportDomainService,
-            IMapper mapper
-        ) : IRequestHandler<GetAllInvoiceReportQuery, Result<IEnumerable<InvoiceReportGroupDto>, Error>>
+    (
+        IInvoiceReportDomainService invoiceReportDomainService,
+        IMapper mapper,
+        IRedisService redisService
+    ) : IRequestHandler<GetAllInvoiceReportQuery, Result<IEnumerable<InvoiceReportGroupDto>, Error>>
     {
         public async Task<Result<IEnumerable<InvoiceReportGroupDto>, Error>> Handle(
             GetAllInvoiceReportQuery request,
             CancellationToken cancellationToken)
         {
-            var result = await InvoiceReportDomainService.GetAllAsync(cancellationToken, request.PaginationParams);
+            string cacheKey = $"invoiceReport_{request.PaginationParams.PageNumber}_{request.PaginationParams.PageSize}";
+
+            var cachedData = await redisService.GetCacheAsync<IEnumerable<InvoiceReportGroupDto>>(cacheKey);
+            if (cachedData is not null)
+            {
+                return Result<IEnumerable<InvoiceReportGroupDto>, Error>.Success(cachedData);
+            }
+
+            var result = await invoiceReportDomainService.GetAllAsync(cancellationToken, request.PaginationParams);
 
             if (!result.IsSuccess || result.Value == null)
                 return result.Error!;
@@ -29,7 +39,10 @@ namespace Poliedro.Report.Application.InvoiceReport.Queries.GetAllInvoiceReport
                         g.First().ContactName,
                         mapper.Map<List<InvoiceDetailReportDto>>(g.ToList())
                     )
-                );
+                ).ToList();
+
+            await redisService.SetCacheAsync(cacheKey, grouped, TimeSpan.FromMinutes(1440));
+
             return Result<IEnumerable<InvoiceReportGroupDto>, Error>.Success(grouped);
         }
     }

--- a/Poliedro.Report.Application/PaymentMethodReport/Queries/GetAllPaymentMethodReport/GetAllPaymentMethodReportQueryHandler.cs
+++ b/Poliedro.Report.Application/PaymentMethodReport/Queries/GetAllPaymentMethodReport/GetAllPaymentMethodReportQueryHandler.cs
@@ -4,24 +4,37 @@ using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
 using Poliedro.Report.Application.PaymentMethodReport.Dtos;
 using Poliedro.Report.Domain.PaymentMethodReport.Ports;
+using StackExchange.Redis;
+using System.Text.Json;
 
 namespace Poliedro.Report.Application.PaymentMethodReport.Queries.GetAllPaymentMethodReport;
 
 public class GetAllPaymentMethodReportQueryHandler(
     IPaymentMethodReportDomain paymentMethodReportDomain,
-    IMapper mapper
+    IMapper mapper,
+    IConnectionMultiplexer redis
 ) : IRequestHandler<GetAllPaymentMethodReportQuery, Result<PaymentMethodReportDto, Error>>
-
 {
     public async Task<Result<PaymentMethodReportDto, Error>> Handle(
-    GetAllPaymentMethodReportQuery request,
-    CancellationToken cancellationToken)
+        GetAllPaymentMethodReportQuery request,
+        CancellationToken cancellationToken)
     {
-        var result = await paymentMethodReportDomain.GetAllAsync(cancellationToken, request.PaginationParams);
+        var db = redis.GetDatabase();
+        var cacheKey = $"payment-method-report:{JsonSerializer.Serialize(request.PaginationParams)}";
 
+
+        var cachedData = await db.StringGetAsync(cacheKey);
+        if (cachedData.HasValue)
+        {
+            var deserialized = JsonSerializer.Deserialize<PaymentMethodReportDto>(cachedData);
+            if (deserialized != null)
+                return Result<PaymentMethodReportDto, Error>.Success(deserialized);
+        }
+
+
+        var result = await paymentMethodReportDomain.GetAllAsync(cancellationToken, request.PaginationParams);
         if (!result.IsSuccess || result.Value is null)
             return result.Error!;
-
 
         var response = new PaymentMethodReportDto(new(), new(), new())
         {
@@ -30,7 +43,10 @@ public class GetAllPaymentMethodReportQueryHandler(
             ForDay = mapper.Map<List<PaymentMethodReportDayDto>>(result.Value.ForDay),
         };
 
-        return response;
-    }
 
+        var jsonData = JsonSerializer.Serialize(response);
+        await db.StringSetAsync(cacheKey, jsonData, TimeSpan.FromHours(1));
+
+        return Result<PaymentMethodReportDto, Error>.Success(response);
+    }
 }

--- a/Poliedro.Report.Application/Poliedro.Report.Application.csproj
+++ b/Poliedro.Report.Application/Poliedro.Report.Application.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="FluentValidation" Version="11.11.0" />
     <PackageReference Include="MediatR" Version="12.5.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.8.31" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Poliedro.Report.Application/SalesReport/Queries/GetAllSalesReport/GetAllSalesReportQueryHandler.cs
+++ b/Poliedro.Report.Application/SalesReport/Queries/GetAllSalesReport/GetAllSalesReportQueryHandler.cs
@@ -1,39 +1,42 @@
-﻿
-using AutoMapper;
+﻿using AutoMapper;
 using MediatR;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
 using Poliedro.Report.Application.SalesReport.Dtos;
 using Poliedro.Report.Domain.SalesReport.Ports;
+using Poliedro.Report.Application.Ports.Redis;
 
 namespace Poliedro.Report.Application.SalesReport.Queries.GetAllSalesReport;
 
-    public class GetAllSalesReportQueryHandler(
-        ISalesReportDomain SalesReportDomain,
-        IMapper mapper
-        ) : IRequestHandler<GetAllSalesReportQuery, Result<SalesReportDto, Error>>
-    {
-        public async Task<Result<SalesReportDto, Error>> Handle(
+public class GetAllSalesReportQueryHandler(
+    ISalesReportDomain SalesReportDomain,
+    IMapper mapper,
+    IRedisService redisService
+) : IRequestHandler<GetAllSalesReportQuery, Result<SalesReportDto, Error>>
+{
+    public async Task<Result<SalesReportDto, Error>> Handle(
         GetAllSalesReportQuery request,
         CancellationToken cancellationToken)
+    {
+        string cacheKey = $"salesReport_{request.PaginationParams.PageNumber}_{request.PaginationParams.PageSize}";
+        var cachedData = await redisService.GetCacheAsync<SalesReportDto>(cacheKey);
+        if (cachedData is not null)
+            return cachedData;
+
+        var result = await SalesReportDomain.GetAllAsync(cancellationToken, request.PaginationParams);
+
+        if (!result.IsSuccess || result.Value is null)
+            return result.Error!;
+
+        var response = new SalesReportDto(new(), new(), new())
         {
-            var result = await SalesReportDomain.GetAllAsync(cancellationToken, request.PaginationParams);
+            ForYear = mapper.Map<List<SalesReportYearDto>>(result.Value.ForYear),
+            ForMonth = mapper.Map<List<SalesReportMonthDto>>(result.Value.ForMonth),
+            ForDay = mapper.Map<List<SalesReportDayDto>>(result.Value.ForDay),
+        };
 
-            if (!result.IsSuccess || result.Value is null)
-                return result.Error!;
+        await redisService.SetCacheAsync(cacheKey, response, TimeSpan.FromMinutes(10));
 
-
-
-            var response = new SalesReportDto(new(), new(), new())
-            {
-                ForYear = mapper.Map<List<SalesReportYearDto>>(result.Value.ForYear),
-                ForMonth = mapper.Map<List<SalesReportMonthDto>>(result.Value.ForMonth),
-                ForDay = mapper.Map<List<SalesReportDayDto>>(result.Value.ForDay),
-            };
-
-            return response;
-        }
-
+        return response;
     }
-
-
+}

--- a/Poliedro.Report.Application/SuppliersReport/Queries/GetAllSuppliersReport/GetAllSuppliersReportQueryHandler.cs
+++ b/Poliedro.Report.Application/SuppliersReport/Queries/GetAllSuppliersReport/GetAllSuppliersReportQueryHandler.cs
@@ -4,23 +4,31 @@ using Poliedro.Billing.Application.SuppliersReport.Dtos;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
 using Poliedro.Billing.Domain.SuppliersReport.DomainSuppliersReport;
+using Poliedro.Report.Application.Ports.Redis;
 
 namespace Poliedro.Billing.Application.SuppliersReport.Queries.GetAllUtilityReport;
 
-public class GetAllSuppliersReportQueryHandler
-(
+public class GetAllSuppliersReportQueryHandler(
     ISuppliersReportDomainSuppliersReport suppliersreportDomainSuppliersReport,
-    IMapper mapper
+    IMapper mapper,
+    IRedisService redisService
 ) : IRequestHandler<GetAllSuppliersReportQuery, Result<IEnumerable<SuppliersReportDto>, Error>>
 {
-
     public async Task<Result<IEnumerable<SuppliersReportDto>, Error>>
         Handle(GetAllSuppliersReportQuery request, CancellationToken cancellationToken)
     {
+        string cacheKey = $"suppliersReport_{request.PaginationParams.PageNumber}_{request.PaginationParams.PageSize}";
+        var cachedData = await redisService.GetCacheAsync<IEnumerable<SuppliersReportDto>>(cacheKey);
+        if (cachedData is not null)
+            return cachedData.ToList();
+
         var result = await suppliersreportDomainSuppliersReport.GetAllAsync(cancellationToken, request.PaginationParams);
-        if (!result.IsSuccess && result.Value != null)
+        if (!result.IsSuccess || result.Value is null)
             return result.Error!;
 
-        return mapper.Map<List<SuppliersReportDto>>(result.Value);
+        var mapped = mapper.Map<List<SuppliersReportDto>>(result.Value);
+        await redisService.SetCacheAsync(cacheKey, mapped, TimeSpan.FromMinutes(5));
+
+        return mapped;
     }
 }

--- a/Poliedro.Report.Application/UtilityReport/Queries/GetAllUtilityReport/GetAllUtilityReportQueryHandler.cs
+++ b/Poliedro.Report.Application/UtilityReport/Queries/GetAllUtilityReport/GetAllUtilityReportQueryHandler.cs
@@ -1,8 +1,8 @@
-﻿
-using AutoMapper;
+﻿using AutoMapper;
 using MediatR;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
+using Poliedro.Report.Application.Ports.Redis;
 using Poliedro.Report.Application.UtilityReport.Dtos;
 using Poliedro.Report.Domain.UtilityReport.Ports;
 
@@ -10,13 +10,20 @@ namespace Poliedro.Report.Application.UtilityReport.Queries.GetAllUtilityReport
 {
     public class GetAllUtilityReportQueryHandler(
         IUtilityReportDomain utilityReportDomain,
-        IMapper mapper
+        IMapper mapper,
+        IRedisService redisService
     ) : IRequestHandler<GetAllUtilityReportQuery, Result<UtilityReportDto, Error>>
     {
         public async Task<Result<UtilityReportDto, Error>> Handle(
             GetAllUtilityReportQuery request,
             CancellationToken cancellationToken)
         {
+            string cacheKey = $"utilityReport_{request.PaginationParams.PageNumber}_{request.PaginationParams.PageSize}";
+
+            var cachedData = await redisService.GetCacheAsync<UtilityReportDto>(cacheKey);
+            if (cachedData is not null)
+                return cachedData;
+
             var result = await utilityReportDomain.GetAllAsync(cancellationToken, request.PaginationParams);
 
             if (!result.IsSuccess || result.Value is null)
@@ -27,6 +34,9 @@ namespace Poliedro.Report.Application.UtilityReport.Queries.GetAllUtilityReport
                 ForMonth: mapper.Map<List<UtilityReportMonthDto>>(result.Value.ForMonth),
                 ForDay: mapper.Map<List<UtilityReportDayDto>>(result.Value.ForDay)
             );
+
+
+            await redisService.SetCacheAsync(cacheKey, response, TimeSpan.FromMinutes(30));
 
             return response;
         }

--- a/Poliedro.Report.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
+++ b/Poliedro.Report.Infraestructure.Persistence.Mysql/DependencyInjectionService.cs
@@ -9,7 +9,6 @@ using Poliedro.Report.Domain.PaymentMethodReport.Ports;
 using Poliedro.Report.Domain.InvoiceReport.Ports;
 using Poliedro.Report.Domain.UtilityReport.Ports;
 using Poliedro.Report.Domain.SalesReport.Ports;
-using Poliedro.Report.Application.Ports.Redis;
 using Poliedro.Report.Infraestructure.Persistence.Mysql.Adapter;
 using Poliedro.Report.Infraestructure.Persistence.Mysql.Context;
 using Poliedro.Report.Infraestructure.Persistence.Mysql.InventoryReport.Impl;
@@ -18,7 +17,6 @@ using Poliedro.Report.Infraestructure.Persistence.Mysql.PaymentMethodReport.Impl
 using Poliedro.Report.Infraestructure.Persistence.Mysql.InvoiceReport.Impl;
 using Poliedro.Report.Infraestructure.Persistence.Mysql.UtilityReport.ImpI;
 using Poliedro.Report.Infraestructure.Persistence.Mysql.SalesReport.ImpI;
-using Poliedro.Report.Infraestructure.Persistence.Mysql.Redis;
 using Poliedro.Report.Infraestructure.Persistence.Mysql.DraftReport.Impl;
 
 namespace Poliedro.Report.Infraestructure.Persistence.Mysql;
@@ -31,7 +29,7 @@ public static class DependencyInjectionService
         services.AddDbContext<DataBaseContext>(
             options => options.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString)
         ));
-      
+
         services.AddTransient<IMessageProvider, MessageProvider>();
         services.AddTransient<ISuppliersReportDomainSuppliersReport, SuppliersReportDomainService>();
         services.AddTransient<IInventoryReportDomainInventoryReport, InventoryReportDomainService>();
@@ -41,8 +39,6 @@ public static class DependencyInjectionService
         services.AddTransient<ISalesReportDomain, SalesReportDomainService>();
         services.AddTransient<IDraftReportDomainDraftReport, DraftReportDomainService>();
 
-
-        services.AddTransient<IRedisService, RedisCacheService>();
         return services;
     }
 }

--- a/Poliedro.Report.Infraestructure.Persistence.Mysql/DraftReport2/Impl/DraftReportBillingDomainService.cs
+++ b/Poliedro.Report.Infraestructure.Persistence.Mysql/DraftReport2/Impl/DraftReportBillingDomainService.cs
@@ -5,23 +5,17 @@ using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
 using Poliedro.Billing.Domain.DraftReport.DomainDraftReport;
 using Poliedro.Billing.Domain.DraftReport.Entities;
-using Poliedro.Report.Application.Ports.Redis;
 
 
 namespace Poliedro.Report.Infraestructure.Persistence.Mysql.DraftReport.Impl;
 
-public class DraftReportDomainService(IConfiguration config, IRedisService redisService) : IDraftReportDomainDraftReport
+public class DraftReportDomainService(IConfiguration config) : IDraftReportDomainDraftReport
 {
     private readonly string _connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? config["ConnectionStrings:MysqlConnection"];
 
     public async Task<Result<IEnumerable<DraftReportEntity>, Error>> GetAllAsync(CancellationToken cancellationToken, PaginationParams paginationParams)
     {
-        List<DraftReportEntity> draftReports = new();
-
-        string cacheKey = $"draftReport_{paginationParams.PageNumber}_{paginationParams.PageSize}";
-        var cachedData = await redisService.GetCacheAsync<IEnumerable<DraftReportEntity>>(cacheKey);
-        if (cachedData is not null) return Result<IEnumerable<DraftReportEntity>, Error>.Success(cachedData);
-
+        List<DraftReportEntity> draftReports = [];
         using MySqlConnection connection = new(_connectionString);
         try
         {
@@ -55,8 +49,6 @@ public class DraftReportDomainService(IConfiguration config, IRedisService redis
                     draftReports.Add(report);
                 }
             }
-
-            await redisService.SetCacheAsync(cacheKey, draftReports, TimeSpan.FromMinutes(1440));
             return Result<IEnumerable<DraftReportEntity>, Error>.Success(draftReports);
         }
         catch (Exception ex)

--- a/Poliedro.Report.Infraestructure.Persistence.Mysql/InventoryReport/Impl/InventoryReportBillingDomainService.cs
+++ b/Poliedro.Report.Infraestructure.Persistence.Mysql/InventoryReport/Impl/InventoryReportBillingDomainService.cs
@@ -5,65 +5,58 @@ using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
 using Poliedro.Billing.Domain.InventoryReport.DomainInventoryReport;
 using Poliedro.Billing.Domain.InventoryReport.Entities;
-using Poliedro.Report.Application.Ports.Redis;
-
 
 namespace Poliedro.Report.Infraestructure.Persistence.Mysql.InventoryReport.Impl;
 
-public class InventoryReportDomainService(IConfiguration config, IRedisService redisService) : IInventoryReportDomainInventoryReport
+public class InventoryReportDomainService(IConfiguration config) : IInventoryReportDomainInventoryReport
 {
     private readonly string _connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? config["ConnectionStrings:MysqlConnection"];
 
     public async Task<Result<IEnumerable<InventoryReportEntity>, Error>> GetAllAsync(CancellationToken cancellationToken, PaginationParams paginationParams)
-{
-    List<InventoryReportEntity> inventoryReports = new();
-    
-    string cacheKey = $"inventoryReport_{paginationParams.PageNumber}_{paginationParams.PageSize}";
-    var cachedData = await redisService.GetCacheAsync<IEnumerable<InventoryReportEntity>>(cacheKey);
-    if (cachedData is not null) return Result<IEnumerable<InventoryReportEntity>, Error>.Success(cachedData); 
-
-    using MySqlConnection connection = new(_connectionString);
-    try
     {
-        await connection.OpenAsync(cancellationToken);
+        List<InventoryReportEntity> inventoryReports = [];
 
-        int offset = (paginationParams.PageNumber - 1) * paginationParams.PageSize;
-        string query = "SELECT * FROM v_inventario LIMIT @PageSize OFFSET @Offset";
-        
-        using MySqlCommand command = new(query, connection);
-        command.Parameters.AddWithValue("@PageSize", paginationParams.PageSize);
-        command.Parameters.AddWithValue("@Offset", offset);
-
-        using MySqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
-
-        while (await reader.ReadAsync(cancellationToken))
+        using MySqlConnection connection = new(_connectionString);
+        try
         {
-            if (reader.GetDecimal(3) > 0)
+            await connection.OpenAsync(cancellationToken);
+
+            int offset = (paginationParams.PageNumber - 1) * paginationParams.PageSize;
+            string query = "SELECT * FROM v_inventario LIMIT @PageSize OFFSET @Offset";
+
+            using MySqlCommand command = new(query, connection);
+            command.Parameters.AddWithValue("@PageSize", paginationParams.PageSize);
+            command.Parameters.AddWithValue("@Offset", offset);
+
+            using MySqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+
+            while (await reader.ReadAsync(cancellationToken))
             {
-                InventoryReportEntity report = new()
+                if (reader.GetDecimal(3) > 0)
                 {
-                    SKU = reader.GetString(0),
-                    Name = reader.GetString(1),
-                    Presentation = reader.GetString(2),
-                    Cost = reader.GetDecimal(3),
-                    Sale = reader.GetDecimal(4),
-                    Inventory = reader.GetDecimal(5),
-                    Percentage = reader.GetDecimal(6),
-                    Subtotal_Cost = reader.GetDecimal(7),
-                    Subtotal_sale = reader.GetDecimal(8),
-                };
-                inventoryReports.Add(report);
+                    InventoryReportEntity report = new()
+                    {
+                        SKU = reader.GetString(0),
+                        Name = reader.GetString(1),
+                        Presentation = reader.GetString(2),
+                        Cost = reader.GetDecimal(3),
+                        Sale = reader.GetDecimal(4),
+                        Inventory = reader.GetDecimal(5),
+                        Percentage = reader.GetDecimal(6),
+                        Subtotal_Cost = reader.GetDecimal(7),
+                        Subtotal_sale = reader.GetDecimal(8),
+                    };
+                    inventoryReports.Add(report);
+                }
             }
+
+            return Result<IEnumerable<InventoryReportEntity>, Error>.Success(inventoryReports);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Database error: {ex.Message}");
         }
 
-        await redisService.SetCacheAsync(cacheKey, inventoryReports, TimeSpan.FromMinutes(1440));
-        return Result<IEnumerable<InventoryReportEntity>, Error>.Success(inventoryReports);
+        return Result<IEnumerable<InventoryReportEntity>, Error>.Failure(null);
     }
-    catch (Exception ex)
-    {
-        Console.WriteLine($"Database error: {ex.Message}");
-    }
-
-    return Result<IEnumerable<InventoryReportEntity>, Error>.Failure(null);
-}
 }

--- a/Poliedro.Report.Infraestructure.Persistence.Mysql/InvoiceReport/Impl/InvoiceReportDomainService.cs.cs
+++ b/Poliedro.Report.Infraestructure.Persistence.Mysql/InvoiceReport/Impl/InvoiceReportDomainService.cs.cs
@@ -3,13 +3,12 @@ using MySqlConnector;
 using Poliedro.Billing.Domain.Common.Pagination;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
-using Poliedro.Report.Application.Ports.Redis;
 using Poliedro.Report.Domain.InvoiceReport.Entities;
 using Poliedro.Report.Domain.InvoiceReport.Ports;
 
 namespace Poliedro.Report.Infraestructure.Persistence.Mysql.InvoiceReport.Impl;
 
-public class InvoiceReportDomainService(IConfiguration config, IRedisService redisService) : IInvoiceReportDomainService
+public class InvoiceReportDomainService(IConfiguration config) : IInvoiceReportDomainService
 {
     private readonly string _connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? config["ConnectionStrings:MysqlConnection"];
 
@@ -17,42 +16,38 @@ public class InvoiceReportDomainService(IConfiguration config, IRedisService red
     {
         List<InvoiceReportEntity> invoiceReports = new();
 
-            string cacheKey = $"invoiceReport_{paginationParams.PageNumber}_{paginationParams.PageSize}";
-            var cachedData = await redisService.GetCacheAsync<IEnumerable<InvoiceReportEntity>>(cacheKey);
-            if (cachedData is not null) return Result<IEnumerable<InvoiceReportEntity>, Error>.Success(cachedData); 
-
-
-
         using MySqlConnection connection = new(_connectionString);
         try
         {
             await connection.OpenAsync(cancellationToken);
 
             string query = @"
-                    SELECT 
-                        v_invoice_detail.id,
-                        v_invoice_detail.transaccion,
-                        v_invoice_detail.code,
-                        v_invoice_detail.type_item_identification_id,
-                        v_invoice_detail.description,
-                        v_invoice_detail.unit_measure_id,
-                        v_invoice_detail.base_quantity,
-                        v_invoice_detail.invoiced_quantity,
-                        v_invoice_detail.price_amount,
-                        v_invoice_detail.line_extension_amount,
-                        v_invoice_detail.percent,
-                        v_invoice_detail.tax_amount,
-                        v_invoice_detail.unit_price,
-                        v_invoice.contact_name
-                    FROM 
-                        v_invoice_detail
-                    JOIN 
-                        v_invoice ON v_invoice_detail.transaccion = v_invoice.id
-                    LIMIT @Pagesize OFFSET @Offset";
+                SELECT 
+                    v_invoice_detail.id,
+                    v_invoice_detail.transaccion,
+                    v_invoice_detail.code,
+                    v_invoice_detail.type_item_identification_id,
+                    v_invoice_detail.description,
+                    v_invoice_detail.unit_measure_id,
+                    v_invoice_detail.base_quantity,
+                    v_invoice_detail.invoiced_quantity,
+                    v_invoice_detail.price_amount,
+                    v_invoice_detail.line_extension_amount,
+                    v_invoice_detail.percent,
+                    v_invoice_detail.tax_amount,
+                    v_invoice_detail.unit_price,
+                    v_invoice.contact_name
+                FROM 
+                    v_invoice_detail
+                JOIN 
+                    v_invoice ON v_invoice_detail.transaccion = v_invoice.id
+                LIMIT @PageSize OFFSET @Offset";
+
             int offset = (paginationParams.PageNumber - 1) * paginationParams.PageSize;
             using MySqlCommand command = new(query, connection);
             command.Parameters.AddWithValue("@PageSize", paginationParams.PageSize);
             command.Parameters.AddWithValue("@Offset", offset);
+
             using (var reader = await command.ExecuteReaderAsync(cancellationToken))
             {
                 while (await reader.ReadAsync(cancellationToken))

--- a/Poliedro.Report.Infraestructure.Persistence.Mysql/PaymentMethodReport/Impl/PaymentMethodReportDomainService.cs
+++ b/Poliedro.Report.Infraestructure.Persistence.Mysql/PaymentMethodReport/Impl/PaymentMethodReportDomainService.cs
@@ -4,12 +4,11 @@ using Poliedro.Report.Domain.PaymentMethodReport.Ports;
 using Poliedro.Report.Domain.PaymentMethodReport.Entity;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
-using Poliedro.Report.Application.Ports.Redis;
 using Poliedro.Billing.Domain.Common.Pagination;
 
 namespace Poliedro.Report.Infraestructure.Persistence.Mysql.PaymentMethodReport.Impl;
 
-public class PaymentMethodReportDomainService(IConfiguration config, IRedisService redisService) : IPaymentMethodReportDomain
+public class PaymentMethodReportDomainService(IConfiguration config) : IPaymentMethodReportDomain
 {
     private readonly string _connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? config["ConnectionStrings:MysqlConnection"];
 
@@ -17,31 +16,25 @@ public class PaymentMethodReportDomainService(IConfiguration config, IRedisServi
     {
         PaymentMethodReportEntity paymentReports = new();
 
-            string cacheKey = $"paymentReport_{paginationParams.PageNumber}_{paginationParams.PageSize}";
-            var cachedData = await redisService.GetCacheAsync<PaymentMethodReportEntity>(cacheKey);
-            if (cachedData is not null) return Result<PaymentMethodReportEntity, Error>.Success(cachedData); 
-
-
         using MySqlConnection connection = new(_connectionString);
         try
         {
             await connection.OpenAsync(cancellationToken);
 
-            int offset = (paginationParams.PageNumber -1) * paginationParams.PageSize;
-
+            int offset = (paginationParams.PageNumber - 1) * paginationParams.PageSize;
 
             string queryYear = "SELECT * FROM v_sales_for_pay_method_for_year LIMIT @Pagesize OFFSET @Offset";
-            using (MySqlCommand cmd = new(queryYear, connection)){
-
+            using (MySqlCommand cmd = new(queryYear, connection))
+            {
                 cmd.Parameters.AddWithValue("@Pagesize", paginationParams.PageSize);
                 cmd.Parameters.AddWithValue("@Offset", offset);
-            
-            using (var reader = await cmd.ExecuteReaderAsync(cancellationToken))
-            {
-                while (await reader.ReadAsync(cancellationToken))
+
+                using (var reader = await cmd.ExecuteReaderAsync(cancellationToken))
                 {
-                    paymentReports.ForYear.Add(new PaymentMethodReportYearEntity
+                    while (await reader.ReadAsync(cancellationToken))
                     {
+                        paymentReports.ForYear.Add(new PaymentMethodReportYearEntity
+                        {
                             Year = reader.GetInt32(0),
                             PaymentMethod = reader.GetString(1),
                             TotalPaid = reader.GetDecimal(2),
@@ -52,7 +45,6 @@ public class PaymentMethodReportDomainService(IConfiguration config, IRedisServi
                 }
             }
 
-            
             string queryMonth = "SELECT * FROM v_sales_for_pay_method_for_month";
             using (MySqlCommand cmd = new(queryMonth, connection))
             using (var reader = await cmd.ExecuteReaderAsync(cancellationToken))
@@ -73,27 +65,27 @@ public class PaymentMethodReportDomainService(IConfiguration config, IRedisServi
             }
 
             string queryDay = "SELECT * FROM v_sales_for_pay_method_for_day LIMIT @Pagesize OFFSET @Offset";
-            using (MySqlCommand cmd = new(queryDay, connection)){
-
+            using (MySqlCommand cmd = new(queryDay, connection))
+            {
                 cmd.Parameters.AddWithValue("@PageSize", paginationParams.PageSize);
                 cmd.Parameters.AddWithValue("@Offset", offset);
-            
-            using (var reader = await cmd.ExecuteReaderAsync(cancellationToken))
-            {
-                while (await reader.ReadAsync(cancellationToken))
+
+                using (var reader = await cmd.ExecuteReaderAsync(cancellationToken))
                 {
-                    paymentReports.ForDay.Add(new PaymentMethodReportDayEntity
+                    while (await reader.ReadAsync(cancellationToken))
                     {
-                        Date = reader.GetDateTime(0),
-                        PaymentMethod = reader.GetString(1),
-                        TotalPaid = reader.GetDecimal(2),
-                        TotalSales = reader.GetDecimal(3),
-                        InvoiceQuantity = reader.GetInt64(4),
-                        TotalSalesDay = reader.GetDecimal(5)
-                    });
+                        paymentReports.ForDay.Add(new PaymentMethodReportDayEntity
+                        {
+                            Date = reader.GetDateTime(0),
+                            PaymentMethod = reader.GetString(1),
+                            TotalPaid = reader.GetDecimal(2),
+                            TotalSales = reader.GetDecimal(3),
+                            InvoiceQuantity = reader.GetInt64(4),
+                            TotalSalesDay = reader.GetDecimal(5)
+                        });
+                    }
                 }
             }
-        }
 
             return Result<PaymentMethodReportEntity, Error>.Success(paymentReports);
         }

--- a/Poliedro.Report.Infraestructure.Persistence.Mysql/Poliedro.Report.Infraestructure.Persistence.Mysql.csproj
+++ b/Poliedro.Report.Infraestructure.Persistence.Mysql/Poliedro.Report.Infraestructure.Persistence.Mysql.csproj
@@ -8,6 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="EntityFramework\**" />
+    <EmbeddedResource Remove="EntityFramework\**" />
+    <None Remove="EntityFramework\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
     <PackageReference Include="PDFsharp" Version="6.1.1" />
@@ -33,10 +39,6 @@
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>MessageProviderResource.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="EntityFramework\EntityConfigurations\" />
   </ItemGroup>
 
 </Project>

--- a/Poliedro.Report.Infraestructure.Persistence.Mysql/SalesReport/ImpI/SalesReportDomainService.cs
+++ b/Poliedro.Report.Infraestructure.Persistence.Mysql/SalesReport/ImpI/SalesReportDomainService.cs
@@ -1,28 +1,20 @@
-﻿
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using MySqlConnector;
 using Poliedro.Billing.Domain.Common.Pagination;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
-using Poliedro.Report.Application.Ports.Redis;
 using Poliedro.Report.Domain.SalesReport.Entities;
 using Poliedro.Report.Domain.SalesReport.Ports;
 
-
 namespace Poliedro.Report.Infraestructure.Persistence.Mysql.SalesReport.ImpI;
 
-
-public class SalesReportDomainService(IConfiguration config, IRedisService redisService) : ISalesReportDomain
+public class SalesReportDomainService(IConfiguration config) : ISalesReportDomain
 {
     private readonly string _connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? config["ConnectionStrings:MysqlConnection"];
 
     public async Task<Result<SalesReportEntity, Error>> GetAllAsync(CancellationToken cancellationToken, PaginationParams paginationParams)
     {
         SalesReportEntity salesReports = new();
-
-        string cacheKey = $"salesReport_{paginationParams.PageNumber}_{paginationParams.PageSize}";
-        var cachedData = await redisService.GetCacheAsync<SalesReportEntity>(cacheKey);
-        if (cachedData is not null) return Result<SalesReportEntity, Error>.Success(cachedData);
 
         using MySqlConnection connection = new(_connectionString);
         try
@@ -31,10 +23,8 @@ public class SalesReportDomainService(IConfiguration config, IRedisService redis
 
             int offset = (paginationParams.PageNumber - 1) * paginationParams.PageSize;
 
-            string queryYear = "SELECT * FROM v_sales_for_year ";
-
+            string queryYear = "SELECT * FROM v_sales_for_year";
             using (MySqlCommand cmd = new(queryYear, connection))
-
             using (var reader = await cmd.ExecuteReaderAsync(cancellationToken))
             {
                 while (await reader.ReadAsync(cancellationToken))
@@ -47,7 +37,7 @@ public class SalesReportDomainService(IConfiguration config, IRedisService redis
                 }
             }
 
-            string queryMonth = "SELECT * FROM v_sale_for_month ";
+            string queryMonth = "SELECT * FROM v_sale_for_month";
             using (MySqlCommand cmd = new(queryMonth, connection))
             using (var reader = await cmd.ExecuteReaderAsync(cancellationToken))
             {
@@ -66,24 +56,23 @@ public class SalesReportDomainService(IConfiguration config, IRedisService redis
             string queryDay = "SELECT * FROM v_sales_for_day LIMIT @Pagesize OFFSET @Offset";
             using (MySqlCommand cmd = new(queryDay, connection))
             {
-
                 cmd.Parameters.AddWithValue("@Pagesize", paginationParams.PageSize);
                 cmd.Parameters.AddWithValue("@Offset", offset);
 
-            using (var reader = await cmd.ExecuteReaderAsync(cancellationToken))
-            {
-                while (await reader.ReadAsync(cancellationToken))
+                using (var reader = await cmd.ExecuteReaderAsync(cancellationToken))
                 {
-                    salesReports.ForDay.Add(new SalesReportDayEntity
+                    while (await reader.ReadAsync(cancellationToken))
                     {
-                        Date = reader.GetDateTime(0),
-                        NumberMonth = reader.GetInt32(1),
-                        Month = reader.GetString(2),
-                        Year = reader.GetInt32(3),
-                        Sale = reader.GetDecimal(4)
-                    });
+                        salesReports.ForDay.Add(new SalesReportDayEntity
+                        {
+                            Date = reader.GetDateTime(0),
+                            NumberMonth = reader.GetInt32(1),
+                            Month = reader.GetString(2),
+                            Year = reader.GetInt32(3),
+                            Sale = reader.GetDecimal(4)
+                        });
+                    }
                 }
-            }
             }
 
             return Result<SalesReportEntity, Error>.Success(salesReports);

--- a/Poliedro.Report.Infraestructure.Persistence.Mysql/SuppliersReport/DomainSuppliersReport/Impl/SuppliersReportDomainService.cs
+++ b/Poliedro.Report.Infraestructure.Persistence.Mysql/SuppliersReport/DomainSuppliersReport/Impl/SuppliersReportDomainService.cs
@@ -5,11 +5,10 @@ using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
 using Poliedro.Billing.Domain.SuppliersReport.DomainSuppliersReport;
 using Poliedro.Billing.Domain.SuppliersReport.Entities;
-using Poliedro.Report.Application.Ports.Redis;
 
 namespace Poliedro.Billing.Infraestructure.Persistence.Mysql.SuppliersReport.DomainService.Impl;
 
-public class SuppliersReportDomainService(IConfiguration config, IRedisService redisService) : ISuppliersReportDomainSuppliersReport
+public class SuppliersReportDomainService(IConfiguration config) : ISuppliersReportDomainSuppliersReport
 {
     private readonly string _connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? config["ConnectionStrings:MysqlConnection"];
 
@@ -17,22 +16,18 @@ public class SuppliersReportDomainService(IConfiguration config, IRedisService r
     {
         List<SuppliersReportEntity> suppliersReports = new();
 
-        string cacheKey = $"suppliersReport_{paginationParams.PageNumber}_{paginationParams.PageSize}";
-        var cachedData = await redisService.GetCacheAsync<IEnumerable<SuppliersReportEntity>>(cacheKey);
-        if (cachedData is not null) return Result<IEnumerable<SuppliersReportEntity>, Error>.Success(cachedData);
-
         using MySqlConnection connection = new(_connectionString);
         try
         {
             await connection.OpenAsync(cancellationToken);
 
-            int offset = (paginationParams.PageNumber -1) * paginationParams.PageSize;
+            int offset = (paginationParams.PageNumber - 1) * paginationParams.PageSize;
             string query = $"SELECT * FROM v_saldo_por_proveedor"; // LIMIT @PageSize OFFSET @Offset";
 
             using MySqlCommand command = new(query, connection);
             command.Parameters.AddWithValue("@PageSize", paginationParams.PageSize);
             command.Parameters.AddWithValue("@Offset", offset);
-            
+
             using MySqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
 
             while (await reader.ReadAsync(cancellationToken))

--- a/Poliedro.Report.Infraestructure.Persistence.Mysql/UtilityReport/ImpI/UtilityReportDomainService.cs
+++ b/Poliedro.Report.Infraestructure.Persistence.Mysql/UtilityReport/ImpI/UtilityReportDomainService.cs
@@ -3,13 +3,12 @@ using MySqlConnector;
 using Poliedro.Billing.Domain.Common.Pagination;
 using Poliedro.Billing.Domain.Common.Results;
 using Poliedro.Billing.Domain.Common.Results.Errors;
-using Poliedro.Report.Application.Ports.Redis;
 using Poliedro.Report.Domain.UtilityReport.Entity;
 using Poliedro.Report.Domain.UtilityReport.Ports;
 
 namespace Poliedro.Report.Infraestructure.Persistence.Mysql.UtilityReport.ImpI;
 
-public class UtilityReportDomainService(IConfiguration config, IRedisService redisService) : IUtilityReportDomain
+public class UtilityReportDomainService(IConfiguration config) : IUtilityReportDomain
 {
     private readonly string _connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION") ?? config["ConnectionStrings:MysqlConnection"];
 
@@ -17,22 +16,18 @@ public class UtilityReportDomainService(IConfiguration config, IRedisService red
     {
         UtilityReportEntity utilityReports = new();
 
-        string cacheKey = $"utilityReport_{paginationParams.PageNumber}_{paginationParams.PageSize}";
-        var cachedData = await redisService.GetCacheAsync<UtilityReportEntity>(cacheKey);
-        if (cachedData is not null) return Result<UtilityReportEntity, Error>.Success(cachedData);
-
         using MySqlConnection connection = new(_connectionString);
         try
         {
             await connection.OpenAsync(cancellationToken);
-            int offset = (paginationParams.PageNumber -1) * paginationParams.PageSize;
+            int offset = (paginationParams.PageNumber - 1) * paginationParams.PageSize;
 
             string queryYear = "SELECT * FROM v_utility_for_year LIMIT @PageSize OFFSET @Offset";
             using (MySqlCommand cmd = new(queryYear, connection))
             {
                 cmd.Parameters.AddWithValue("@PageSize", paginationParams.PageSize);
                 cmd.Parameters.AddWithValue("@Offset", offset);
-            
+
                 using (var reader = await cmd.ExecuteReaderAsync(cancellationToken))
                 {
                     while (await reader.ReadAsync(cancellationToken))
@@ -51,7 +46,7 @@ public class UtilityReportDomainService(IConfiguration config, IRedisService red
             {
                 cmd.Parameters.AddWithValue("@PageSize", paginationParams.PageSize);
                 cmd.Parameters.AddWithValue("@Offset", offset);
-            
+
                 using (var reader = await cmd.ExecuteReaderAsync(cancellationToken))
                 {
                     while (await reader.ReadAsync(cancellationToken))


### PR DESCRIPTION
## Summary by Sourcery

Refactor caching by removing Redis dependencies from persistence services and centralizing it in the DraftReport query handler, while updating DI and configuration.

New Features:
- Implement Redis caching in GetAllDraftReportQueryHandler with configurable expiration

Enhancements:
- Remove IRedisService injection and caching logic from all MySQL domain service implementations
- Remove RedisCacheService registration from dependency injection
- Simplify domain service constructors by depending only on configuration

Documentation:
- Add ExpirationInMinutes setting under Redis in appsettings.json