### PR TITLE
chore(redis): add env connection string redis

### DIFF
--- a/Poliedro.Report.Api/Program.cs
+++ b/Poliedro.Report.Api/Program.cs
@@ -27,7 +27,7 @@ builder.Services.AddSingleton<IRedisService, RedisCacheService>();
 
 builder.Services.AddSingleton<IConnectionMultiplexer>(sp =>
 {
-    var configuration = builder.Configuration.GetSection("Redis")["ConnectionString"];
+    var configuration = Environment.GetEnvironmentVariable("REDIS_CONNECTION") ?? builder.Configuration.GetSection("Redis")["ConnectionString"];
     return ConnectionMultiplexer.Connect(configuration);
 });
 

--- a/Poliedro.Report.Api/appsettings.json
+++ b/Poliedro.Report.Api/appsettings.json
@@ -18,7 +18,7 @@
     "http://52.14.223.70/"
   ],
   "Redis": {
-    "ConnectionString": "3.16.55.93:6379",
+    "ConnectionString": "3.14.7.119:6379",
     "ExpirationInMinutes": 1440
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Allow overriding the Redis connection string via an environment variable and update the default Redis endpoint

Enhancements:
- Load Redis connection string from REDIS_CONNECTION environment variable before falling back to appsettings.json
- Update default Redis connection string in appsettings.json to 3.14.7.119:6379